### PR TITLE
Filter action runs locally

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,8 @@ function trigger_workflow {
 
 function find_workflow {
   counter=0
+  action_start=$(date -d "$(date -u +%T)" +"%s")
+  echo "Action timestamp: ${action_start}"
   while [[ true ]]
   do
     counter=$(( $counter + 1 ))
@@ -25,9 +27,9 @@ function find_workflow {
       -H "Accept: application/vnd.github.v3+json" \
       -H "Authorization: Bearer ${INPUT_TOKEN}" | jq '.workflow_runs[0]')
 
-    wtime=$( echo $(echo $workflow | jq '.created_at') | cut -c13-20 )
-    atime=$(date -u +%T)
-    tdif=$(( $(date -d "$atime" +"%s") - $(date -d "$wtime" +"%s") ))
+    wf_time=$( echo $(echo $workflow | jq '.created_at') | cut -c13-20 )
+    echo "Latest workflow timestamp: ${wf_time}"
+    tdif=$(( ${action_start} - $(date -d "$wtime" +"%s") ))
     
     if [[ "$tdif" -gt "10" ]]
     then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,8 +18,8 @@ function trigger_workflow {
 
 function find_workflow {
   counter=0
-  action_start=$(date -d "$(date -u +%T)" +"%s")
-  echo "Action timestamp: ${action_start}"
+  action_start=$(date -u +%T)
+  echo "Action timestamp: $action_start"
   while [[ true ]]
   do
     counter=$(( $counter + 1 ))
@@ -29,7 +29,7 @@ function find_workflow {
 
     wf_time=$( echo $(echo $workflow | jq '.created_at') | cut -c13-20 )
     echo "Latest workflow timestamp: ${wf_time}"
-    tdif=$(( ${action_start} - $(date -d "$wtime" +"%s") ))
+    tdif=$(( $(date -d "$action_start" +"%s") - $(date -d "$wf_time" +"%s") ))
     
     if [[ "$tdif" -gt "10" ]]
     then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,9 +24,15 @@ function find_workflow {
   while [[ true ]]
   do
     counter=$(( $counter + 1 ))
-    workflow=$(curl -s "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/runs" \
+    all_runs=$(curl -s "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/runs" \
       -H "Accept: application/vnd.github.v3+json" \
-      -H "Authorization: Bearer ${INPUT_TOKEN}" | jq '.workflow_runs[0]')
+      -H "Authorization: Bearer ${INPUT_TOKEN}" | jq '.workflow_runs' )
+
+    # Github's API is eventually consistent when filtering by event which can
+    # lead to bad results when using the `event` filter on the API query.
+    # Filter here, instead, to work around this.
+    dispatch_runs=$( echo $(echo $all_runs | jq 'map(select(.event=="repository_dispatch"))') )
+    workflow=$( echo $(echo $dispatch_runs | jq '.[0]') )
 
     # TODO(toby): Remove this debug log
     echo "DEBUG: (Workflow) $workflow"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ function find_workflow {
   while [[ true ]]
   do
     counter=$(( $counter + 1 ))
-    workflow=$(curl -s "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/runs?event=repository_dispatch" \
+    workflow=$(curl -s "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/runs" \
       -H "Accept: application/vnd.github.v3+json" \
       -H "Authorization: Bearer ${INPUT_TOKEN}" | jq '.workflow_runs[0]')
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,7 @@ function trigger_workflow {
 function find_workflow {
   counter=0
   action_start=$(date -u +%T)
+  # TODO(toby): Remove this debug log
   echo "Action timestamp: $action_start"
   while [[ true ]]
   do
@@ -27,7 +28,11 @@ function find_workflow {
       -H "Accept: application/vnd.github.v3+json" \
       -H "Authorization: Bearer ${INPUT_TOKEN}" | jq '.workflow_runs[0]')
 
+    # TODO(toby): Remove this debug log
+    echo "DEBUG: (Workflow) $workflow"
+
     wf_time=$( echo $(echo $workflow | jq '.created_at') | cut -c13-20 )
+    # TODO(toby): Remove this debug log
     echo "Latest workflow timestamp: ${wf_time}"
     tdif=$(( $(date -d "$action_start" +"%s") - $(date -d "$wf_time" +"%s") ))
     


### PR DESCRIPTION
# Problem

The Github API is currently returning stale results when the `event` query param is supplied. They appear to be about 24 hours old. It seems likely that filtered results are eventually consistent and there's some sort of indexing delay on Github's side.

# Solution

Removing the `event` filter from the API request returns up-to-date results. The results are filtered with `jq` instead.